### PR TITLE
Do not wrap lists in additional arrays.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.assume_role_arns}"]
+      identifiers = "${var.assume_role_arns}"
     }
   }
 }
@@ -48,8 +48,8 @@ data "aws_iam_policy_document" "default" {
   }
 
   statement {
-    actions   = ["${var.ssm_actions}"]
-    resources = ["${formatlist("arn:aws:ssm:%s:%s:parameter/%s", var.region, var.account_id, var.ssm_parameters)}"]
+    actions   = "${var.ssm_actions}"
+    resources = "${formatlist("arn:aws:ssm:%s:%s:parameter/%s", var.region, var.account_id, var.ssm_parameters)}"
     effect    = "Allow"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,43 +1,43 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name (e.g. `app` or `chamber`)"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS Region"
 }
 
 variable "account_id" {
-  type        = "string"
+  type        = string
   description = "AWS account ID"
 }
 
@@ -46,18 +46,18 @@ variable "kms_key_reference" {
 }
 
 variable "assume_role_arns" {
-  type        = "list"
+  type        = list
   description = "List of ARNs to allow assuming the role. Could be AWS services or accounts, Kops nodes, IAM users or groups"
 }
 
 variable "ssm_actions" {
-  type        = "list"
+  type        = list
   default     = ["ssm:GetParametersByPath", "ssm:GetParameters"]
   description = "SSM actions to allow"
 }
 
 variable "ssm_parameters" {
-  type        = "list"
+  type        = list
   description = "List of SSM parameters to apply the actions. A parameter can include a path and a name pattern that you define by using forward slashes, e.g. `kops/secret-*`"
 }
 


### PR DESCRIPTION
Some of the lists constructs are wrapped again in `[]`, which TF 0.12.13+ complains about. This is a small fix to remove the extraneous brackets. To avoid warnings under TF 0.12.14, some additional modifications around interpolation will be needed, but are not done in this PR (not sure what the desire is for TF 0.11 compatibility).

Thanks for creating this module!