### PR TITLE
Add account_type & update to TF 0.13 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | account_id | AWS account ID | string | - | yes |
+| account_type | AWS account type | string | `aws` | no |
 | assume_role_arns | List of ARNs to allow assuming the role. Could be AWS services or accounts, Kops nodes, IAM users or groups | list | - | yes |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.1.3"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.5.0"
   attributes = var.attributes
   delimiter  = var.delimiter
   name       = var.name

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "default" {
 
   statement {
     actions   = var.ssm_actions
-    resources = formatlist("arn:aws:ssm:%s:%s:parameter/%s", var.region, var.account_id, var.ssm_parameters)
+    resources = formatlist("arn:%s:ssm:%s:%s:parameter/%s", var.account_type, var.region, var.account_id, var.ssm_parameters)
     effect    = "Allow"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,23 @@
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.1.3"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
 }
 
 locals {
-  policy_only = "${length(var.assume_role_arns) > 0 ? 1 : 0}"
+  policy_only = length(var.assume_role_arns) > 0 ? 1 : 0
 }
 
 data "aws_kms_key" "default" {
-  key_id = "${var.kms_key_reference}"
+  key_id = var.kms_key_reference
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = "${local.policy_only}"
+  count = local.policy_only
 
   statement {
     effect  = "Allow"
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.assume_role_arns}"]
+      identifiers = var.assume_role_arns
     }
   }
 }
@@ -48,36 +48,36 @@ data "aws_iam_policy_document" "default" {
   }
 
   statement {
-    actions   = ["${var.ssm_actions}"]
-    resources = ["${formatlist("arn:aws:ssm:%s:%s:parameter/%s", var.region, var.account_id, var.ssm_parameters)}"]
+    actions   = var.ssm_actions
+    resources = formatlist("arn:aws:ssm:%s:%s:parameter/%s", var.region, var.account_id, var.ssm_parameters)
     effect    = "Allow"
   }
 
   statement {
     actions   = ["kms:Decrypt"]
-    resources = ["${data.aws_kms_key.default.arn}"]
+    resources = [data.aws_kms_key.default.arn]
     effect    = "Allow"
   }
 }
 
 resource "aws_iam_policy" "default" {
-  name        = "${module.label.id}"
+  name        = module.label.id
   description = "Allow SSM actions"
-  policy      = "${data.aws_iam_policy_document.default.json}"
+  policy      = data.aws_iam_policy_document.default.json
 }
 
 resource "aws_iam_role" "default" {
-  count = "${local.policy_only}"
+  count = local.policy_only
 
-  name                 = "${module.label.id}"
-  assume_role_policy   = "${join("",data.aws_iam_policy_document.assume_role.*.json)}"
+  name                 = module.label.id
+  assume_role_policy   = join("",data.aws_iam_policy_document.assume_role.*.json)
   description          = "IAM Role with permissions to perform actions on SSM resources"
-  max_session_duration = "${var.max_session_duration}"
+  max_session_duration = var.max_session_duration
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  count = "${local.policy_only}"
+  count = local.policy_only
 
-  role       = "${join("",aws_iam_role.default.*.name)}"
-  policy_arn = "${join("",aws_iam_policy.default.*.arn)}"
+  role       = join("",aws_iam_role.default.*.name)
+  policy_arn = join("",aws_iam_policy.default.*.arn)
 }

--- a/output.tf
+++ b/output.tf
@@ -1,19 +1,19 @@
 output "role_name" {
-  value       = "${join("",aws_iam_role.default.*.name)}"
-  description = "The name of the crated role"
+  value       = join("",aws_iam_role.default.*.name)
+  description = "The name of the created role"
 }
 
 output "role_id" {
-  value       = "${join("",aws_iam_role.default.*.unique_id)}"
+  value       = join("",aws_iam_role.default.*.unique_id)
   description = "The stable and unique string identifying the role"
 }
 
 output "role_arn" {
-  value       = "${join("",aws_iam_role.default.*.arn)}"
+  value       = join("",aws_iam_role.default.*.arn)
   description = "The Amazon Resource Name (ARN) specifying the role"
 }
 
 output "role_policy_document" {
-  value       = "${data.aws_iam_policy_document.default.json}"
+  value       = data.aws_iam_policy_document.default.json
   description = "A copy of the IAM policy document (JSON) that grants permissions to this role."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "account_id" {
   description = "AWS account ID"
 }
 
+variable "account_type"{
+  type        = string
+  description = "AWS account type e.g. aws or aws-us-gov"
+  default     = "aws"
+}
+
 variable "kms_key_reference" {
   description = "The Key ID, Key ARN, Key Alias Name, or Key Alias ARN of the KMS key which will encrypt/decrypt SSM secret strings"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,43 +1,43 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name (e.g. `app` or `chamber`)"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "AWS Region"
 }
 
 variable "account_id" {
-  type        = "string"
+  type        = string
   description = "AWS account ID"
 }
 
@@ -46,18 +46,18 @@ variable "kms_key_reference" {
 }
 
 variable "assume_role_arns" {
-  type        = "list"
+  type        = list(string)
   description = "List of ARNs to allow assuming the role. Could be AWS services or accounts, Kops nodes, IAM users or groups"
 }
 
 variable "ssm_actions" {
-  type        = "list"
+  type        = list(string)
   default     = ["ssm:GetParametersByPath", "ssm:GetParameters"]
   description = "SSM actions to allow"
 }
 
 variable "ssm_parameters" {
-  type        = "list"
+  type        = list(string)
   description = "List of SSM parameters to apply the actions. A parameter can include a path and a name pattern that you define by using forward slashes, e.g. `kops/secret-*`"
 }
 


### PR DESCRIPTION
Added account type to arn so we can use 'aws-us-gov' instead of 'aws' for arn string construction.

Updated so it's compatible with TF 0.13.