### PR TITLE
Migrate new test account

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -8,3 +8,4 @@ repository:
 
 
 
+

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -8,9 +8,10 @@ permissions:
   pull-requests: write
   id-token: write
   contents: write
+  statuses: write
 
 jobs:
-  terraform-module:
+  test:
     uses: cloudposse/.github/.github/workflows/shared-terraform-chatops.yml@main
-    secrets:
-      github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/terratest') }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,10 @@ on:
     types:
       - published
 
-permissions: {}
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
 
 jobs:
   terraform-module:


### PR DESCRIPTION
## what
- Update `.github/settings.yml` 
- Update `.github/chatops.yml` files

## why
- Re-apply `.github/settings.yml` from org level to get `terratest` environment
- Migrate to new `test` account

## References
* DEV-388 Automate clean up of test account in new organization
* DEV-387 Update terratest to work on a shared workflow instead of a dispatch action
* DEV-386 Update terratest to use new testing account with GitHub OIDC

